### PR TITLE
Notify owner with detailed purchase info

### DIFF
--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -671,18 +671,18 @@ async def buy_item_callback_handler(call: CallbackQuery):
             parent_cat = get_category_parent(item_info_list['category_name'])
 
             if os.path.isfile(value_data['value']):
-                desc = ''
+                photo_desc = ''
                 desc_file = f"{value_data['value']}.txt"
                 if os.path.isfile(desc_file):
                     with open(desc_file) as f:
-                        desc = f.read()
+                        photo_desc = f.read()
                 with open(value_data['value'], 'rb') as media:
                     caption = (
                         f'✅ Item purchased. <b>Balance</b>: <i>{new_balance}</i>€\n'
                         f'📦 Purchases: {purchases}'
                     )
-                    if desc:
-                        caption += f'\n\n{desc}'
+                    if photo_desc:
+                        caption += f'\n\n{photo_desc}'
                     if value_data['value'].endswith('.mp4'):
                         await bot.send_video(
                             chat_id=call.message.chat.id,
@@ -726,7 +726,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                     item_price,
                     parent_cat,
                     item_info_list['category_name'],
-                    desc,
+                    photo_desc,
                     sold_path,
                 )
 

--- a/bot/utils/notifications.py
+++ b/bot/utils/notifications.py
@@ -12,7 +12,7 @@ async def notify_owner_of_purchase(
     item_price: float,
     parent_cat: str | None,
     category_name: str,
-    description: str,
+    photo_description: str,
     file_path: str | None,
 ) -> None:
     """Send purchase details to the bot owner.
@@ -20,14 +20,18 @@ async def notify_owner_of_purchase(
     If ``file_path`` is provided and points to an existing file, the file is sent
     as a photo/video with the details in the caption. Otherwise a text message is
     sent.
+
+    The notification includes the buyer's username, purchase date, product name,
+    price, category, subcategory and photo description.
     """
     text = (
-        f"User {username}\n"
-        f"Time: {formatted_time} GMT+3\n"
-        f"Product: {item_name} ({item_price}€)\n"
-        f"Crypto: N/A\n"
-        f"Category: {parent_cat or '-'} / {category_name}\n"
-        f"Description: {description or '-'}"
+        f"User: {username}\n"
+        f"Date: {formatted_time} GMT+3\n"
+        f"Product: {item_name}\n"
+        f"Price: {item_price}€\n"
+        f"Category: {parent_cat or '-'}\n"
+        f"Subcategory: {category_name}\n"
+        f"Photo description: {photo_description or '-'}"
     )
 
     if file_path and os.path.isfile(file_path):


### PR DESCRIPTION
## Summary
- Send purchase notifications to the owner with username, date, product, price, category, subcategory and photo description.
- Capture and forward item photo descriptions when users buy a file-based item.

## Testing
- `python -m py_compile bot/utils/notifications.py bot/handlers/user/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4df65ed10833283baf229b1311fa5