### PR TITLE
Paginate long shop menus and show statistics in Europe/Vilnius time

### DIFF
--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import shutil
-import datetime
+from zoneinfo import ZoneInfo
 
 from aiogram import Dispatcher
 from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
@@ -622,8 +622,11 @@ async def statistics_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
     if role & Permission.SHOP_MANAGE:
-        today = datetime.datetime.now().strftime("%Y-%m-%d")
+        vilnius_now = datetime.datetime.now(ZoneInfo("Europe/Vilnius"))
+        today = vilnius_now.strftime("%Y-%m-%d")
+        generated_at = vilnius_now.strftime("%Y-%m-%d %H:%M:%S")
         await bot.edit_message_text('Shop statistics:\n'
+                                    f'🕒 Generated at: {generated_at} (Europe/Vilnius)\n'
                                     '➖➖➖➖➖➖➖➖➖➖➖➖➖\n'
                                     '<b>◽USERS</b>\n'
                                     f'◾️Users in last 24h: {select_today_users(today)}\n'

--- a/bot/misc/config.py
+++ b/bot/misc/config.py
@@ -6,6 +6,7 @@ class TgConfig(ABC):
     STATE: Final = {}
     BASKETS: Final = {}
     BLACKJACK_STATS: Final = {}
+    SHOP_PAGES: Final = {}
     CHANNEL_URL: Final = 'https://t.me/+iXbi98gT0v5lOTNk'
     HELPER_URL: Final = '@Karunele'
     REVIEWS_URL: Final = 'https://t.me/+-yPLEiJwp-IxYzlk'


### PR DESCRIPTION
### **User description**
### Motivation
- Prevent Telegram message failures when shop/category/price text exceeds the platform limit by splitting long outputs into pages with navigation. 
- Provide a clear UX for long shop listings using inline navigation and a footer warning. 
- Ensure administrative statistics show timestamps in Lithuania local time including DST using the tz database. 

### Description
- Added `TgConfig.SHOP_PAGES` to store pagination metadata and implemented `_split_shop_text`, `_build_shop_navigation_keyboard`, and `send_or_edit_shop_text` in `bot/handlers/user/main.py` to split content into UTF-8-safe pages and attach navigation. 
- Replaced direct shop/price-list message sends/edits with `send_or_edit_shop_text` for subcategory descriptions and the price list, and added a `shop_page_navigation` callback handler plus registration for `shop_page:` callbacks. 
- Navigation state is keyed by `(chat_id, message_id)` and pages include a footer `⚠️ This menu exceeds Telegram’s message limit. Use the arrows to view more.` when paginated. 
- Updated `bot/handlers/admin/shop_management_states.py` to compute statistics time in `Europe/Vilnius` with `zoneinfo.ZoneInfo` and added a `Generated at` line to the statistics output. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d811ff4208323ab97263f9781e5a5)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement pagination for long shop menus exceeding Telegram's 4096-byte limit
  - Split content into UTF-8-safe pages with navigation arrows
  - Store pagination state by `(chat_id, message_id)` in `TgConfig.SHOP_PAGES`
  - Add footer warning when content is paginated

- Localize admin statistics timestamps to Europe/Vilnius timezone
  - Use `zoneinfo.ZoneInfo` for timezone-aware datetime handling
  - Display "Generated at" timestamp in statistics output

- Integrate pagination into price list and subcategory handlers
  - Replace direct message sends/edits with `send_or_edit_shop_text` function
  - Register `shop_page_navigation` callback handler for pagination controls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long Shop Text"] -->|_split_shop_text| B["Multiple Pages"]
  B -->|_build_shop_navigation_keyboard| C["Paginated Message"]
  C -->|shop_page_navigation| D["Navigate Pages"]
  E["Admin Statistics"] -->|ZoneInfo Europe/Vilnius| F["Localized Timestamp"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shop_management_states.py</strong><dd><code>Localize admin statistics to Europe/Vilnius timezone</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/handlers/admin/shop_management_states.py

<ul><li>Import <code>ZoneInfo</code> from <code>zoneinfo</code> module for timezone handling<br> <li> Replace <code>datetime.datetime.now()</code> with timezone-aware <br><code>datetime.datetime.now(ZoneInfo("Europe/Vilnius"))</code><br> <li> Add "Generated at" line to statistics message showing timestamp in <br>Europe/Vilnius timezone<br> <li> Remove duplicate <code>import datetime</code> statement</ul>


</details>


  </td>
  <td><a href="https://github.com/ereal21/fffffff/pull/5/files#diff-9dafaa6d2ed9bb5c0c653a8e9c833ee33db3c870bad6f7598a3887f0ead4ed5d">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement shop menu pagination with navigation controls</code>&nbsp; &nbsp; </dd></summary>
<hr>

bot/handlers/user/main.py

<ul><li>Add <code>_split_shop_text()</code> function to split text into Telegram-safe pages <br>with UTF-8 byte counting<br> <li> Add <code>_build_shop_navigation_keyboard()</code> function to create pagination <br>controls with arrow buttons<br> <li> Add <code>send_or_edit_shop_text()</code> async function to handle both single and <br>multi-page message sending/editing<br> <li> Add <code>shop_page_navigation()</code> callback handler to process pagination <br>button clicks<br> <li> Update <code>price_list_callback_handler()</code> to use <code>send_or_edit_shop_text()</code> <br>for pagination support<br> <li> Update <code>items_list_callback_handler()</code> to use <code>send_or_edit_shop_text()</code> <br>for pagination support<br> <li> Register <code>shop_page_navigation</code> handler for <code>shop_page:</code> callback data <br>pattern<br> <li> Import <code>copy</code> module for deep copying button structures</ul>


</details>


  </td>
  <td><a href="https://github.com/ereal21/fffffff/pull/5/files#diff-f74953ec387c07256004218669b35955d1fc89125e093e87bf7c15c339066044">+203/-6</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add pagination state storage to config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/misc/config.py

<ul><li>Add <code>SHOP_PAGES</code> dictionary to <code>TgConfig</code> class to store pagination <br>metadata keyed by <code>(chat_id, message_id)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ereal21/fffffff/pull/5/files#diff-32a1e6ec9889bc0a59e6a1876666bc4f9e3999da4433fa712ce9a501ca772de4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

